### PR TITLE
Add support for Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     ],
     keywords='draw graphical primitives tutorial',
     install_requires=[
-        'pygame==2.0.0.dev10'
+        'pygame==2.0.0.dev24'
     ]
 )


### PR DESCRIPTION
Since pygame added support for python 3.9 starting from 2.0.0.dev14 I tested simple_draw with pygame==2.0.0.dev24.
Everything works fine. All tests finished without any errors.
Tested on macOS 10.15.7 with python:

- 3.6.12
- 3.7.9
- 3.8.6
- 3.9.0

It would be great to update requirements for simple_draw to add support python3.9. What do you think?